### PR TITLE
Fixing multi button push

### DIFF
--- a/Yocto_v1_0c/Mode_Pattern.ino
+++ b/Yocto_v1_0c/Mode_Pattern.ino
@@ -162,12 +162,9 @@ void Mode_Pattern(){
             selected_pattern_edited=1;
             // flag for if the pattern was changed and if saved
             selected_pattern_edited_saved=1;
-            // the pattern equals the XOR'd value of buttons pressed, but only 
-            // if more buttons have been pressed than the last time there was a
-            // change in the step button state
-            if (step_button_state >= last_step_button_state){
-              pattern[pattern_buffer][selected_inst][button_pattern_part] ^= (step_button_state ^ last_step_button_state);
-            }
+            // the pattern should only change on a button's state change from
+            // "not pressed" to "pressed." other cases must be ignored.
+            pattern[pattern_buffer][selected_inst][button_pattern_part] ^= ((step_button_state ^ last_step_button_state) & step_button_state);
             last_step_button_state = step_button_state;
           }
         }

--- a/Yocto_v1_0c/Mode_Pattern.ino
+++ b/Yocto_v1_0c/Mode_Pattern.ino
@@ -163,9 +163,13 @@ void Mode_Pattern(){
             // flag for if the pattern was changed since last save
             selected_pattern_edited_saved=1;//flag que le pattern a ete editer depuis la derniere sauvegarde
             //pattern_in_midi_buffer=0;
-            // the pattern equals the value of buttons pressed
-            pattern[pattern_buffer][selected_inst][button_pattern_part] ^= step_button_state ;//le pattern egale la valeur des boutons appuyer 
-            //Serial.println(pattern[pattern_buffer][selected_inst][button_pattern_part],BIN);
+            // the pattern equals the XOR'd value of buttons pressed, but only 
+            // if more buttons have been pressed than the last time there was a
+            // change in the step button state
+            if (step_button_state >= last_step_button_state){
+              pattern[pattern_buffer][selected_inst][button_pattern_part] ^= (step_button_state ^ last_step_button_state);
+            }
+            last_step_button_state = step_button_state;
           }
         }
         else if (!play){//si pas en play

--- a/Yocto_v1_0c/Mode_Pattern.ino
+++ b/Yocto_v1_0c/Mode_Pattern.ino
@@ -157,12 +157,11 @@ void Mode_Pattern(){
             }
           }
           // if shift button not pressed, we return the value of buttons in the edited pattern
-          else{// sinon bouton shift pas appuyer on retourne la valeur des boutons dans dans le pattern editer
+          else{
             // flag for if the pattern was changed since last save
-            selected_pattern_edited=1;//flag que le pattern a ete editer depuis la derniere sauvegarde
-            // flag for if the pattern was changed since last save
-            selected_pattern_edited_saved=1;//flag que le pattern a ete editer depuis la derniere sauvegarde
-            //pattern_in_midi_buffer=0;
+            selected_pattern_edited=1;
+            // flag for if the pattern was changed and if saved
+            selected_pattern_edited_saved=1;
             // the pattern equals the XOR'd value of buttons pressed, but only 
             // if more buttons have been pressed than the last time there was a
             // change in the step button state

--- a/Yocto_v1_0c/Yocto_v1_0c.ino
+++ b/Yocto_v1_0c/Yocto_v1_0c.ino
@@ -117,7 +117,8 @@ boolean  old_din_start_state=2;//variable qui sert achecker le changement de sta
 boolean button_part_switch=1;//variable des deux boutons part appuyer initialise a 1 comme ça au demmarrage les pattern switch automatiquement
 
 // variables which serve to check the step buttons
-//variable qui serve a checker les boutons steps
+// "last_step_button_state" stores the last debounced state of the step button
+// input for pattern edit mode
 //====================================================
 int step_button_state, last_step_button_state=0, old_step_button_state, debounce_step_button_state;//state of the step buttons
 

--- a/Yocto_v1_0c/Yocto_v1_0c.ino
+++ b/Yocto_v1_0c/Yocto_v1_0c.ino
@@ -116,9 +116,10 @@ boolean  old_din_start_state=2;//variable qui sert achecker le changement de sta
 
 boolean button_part_switch=1;//variable des deux boutons part appuyer initialise a 1 comme ça au demmarrage les pattern switch automatiquement
 
+// variables which serve to check the step buttons
 //variable qui serve a checker les boutons steps
 //====================================================
-int step_button_state, old_step_button_state, debounce_step_button_state;//etat des boutons step
+int step_button_state, last_step_button_state=0, old_step_button_state, debounce_step_button_state;//state of the step buttons
 
 //Variable du pattern
 //====================================================


### PR DESCRIPTION
This branch fixes the multi-button push bug, wherein pushing more than one step button at a time during pattern edit mode causes the pattern to be changed in unexpected ways. This fix makes pushing multiple step buttons behave like a typical user would expect. This bug is mentioned on the E-Licktronic forum's official Yocto bugs list: http://www.e-licktronic.com/forum/viewtopic.php?f=17&t=1115