### PR TITLE
Allow rolling of the trigger outs + some refactoring

### DIFF
--- a/Yocto/Check_Edit_Button.ino
+++ b/Yocto/Check_Edit_Button.ino
@@ -31,7 +31,7 @@ void Check_Edit_Button_Pattern_Edit()
         //----------------------
         //check le bouton play
       case 1: // Play button.
-        if(old_selected_mode==0 || old_selected_mode==3){
+        if (sync_mode == MASTER) {
           button_play_count++;
           if(button_play_count==1){
             play=1;
@@ -150,7 +150,7 @@ void Check_Edit_Button_Pattern()
         //----------------------
         //check le bouton play
       case 1:
-        if(sync_mode == MASTER){//selected_mode==0 || selected_mode==3){
+        if (sync_mode == MASTER) {
           button_play_count++;
           if(button_play_count==1){
             //ppqn_count=0;
@@ -165,7 +165,6 @@ void Check_Edit_Button_Pattern()
             first_stop=1;
           }
         }
-        //Serial.println(play,DEC);//DEBUGG
         break;
         //-------------------------
         //check bouton scale

--- a/Yocto/DinSync_out.ino
+++ b/Yocto/DinSync_out.ino
@@ -1,0 +1,18 @@
+// All function related to dinsync handling.
+
+void Set_Dinsync_Clock_High() {
+  PORTD |= (1<<4); // Set the clock high.
+  dinsync_clock_timeout = 4; // 4ms clock.
+}
+
+void Set_Dinsync_Clock_Low() {
+  PORTD &= ~(1<<4); // Lower the clock signal.
+}
+
+void Set_Dinsync_Run_High() {
+  PORTD |= (1<<5); // Set Run = 1.
+}
+
+void Set_Dinsync_Run_Low() {
+  PORTD &= ~(1<<5); // Set Run = 0.
+}

--- a/Yocto/EEprom_Fonction.ino
+++ b/Yocto/EEprom_Fonction.ino
@@ -850,11 +850,11 @@ void Play_Version() {
     byte count = 0;
     while ( count < major_version ) {
       PORTC |= (1 << 7);     
-      PORTB |= (1<<2);//envoie une impulsion sur la sorti trig CPU a chaque pas
+      Set_CPU_Trig_High();
       SR.ShiftOut_Update(temp_step_led,0b10);
       delay(200);
       PORTC &= ~(1 << 7);     
-      PORTB &= ~(1<<2);//envoie une impulsion sur la sorti trig CPU a chaque pas
+      Set_CPU_Trig_Low();
       SR.ShiftOut_Update(temp_step_led,0);
       delay(100);
       count++;
@@ -862,11 +862,11 @@ void Play_Version() {
     count=0;
     while ( count < minor_version ) {
       PORTC |= (1 << 6);     
-      PORTB |= (1<<2);// met a 0 la sorti TRIG CPU
+      Set_CPU_Trig_High();
       SR.ShiftOut_Update(temp_step_led,0b10000000);
       delay(200);
       PORTC &= ~(1 << 6);     
-      PORTB &= ~(1<<2);//envoie une impulsion sur la sorti trig CPU a chaque pas
+      Set_CPU_Trig_Low();
       SR.ShiftOut_Update(temp_step_led,0);
       delay(100);
       count++;

--- a/Yocto/Interruption_fonction.ino
+++ b/Yocto/Interruption_fonction.ino
@@ -10,20 +10,18 @@ void Count_96PPQN()
 
 
 
-  //PORTB &=~(1<<2);// met a 0 la sorti TRIG CPU
+  //Set_CPU_Trig_Low();
   Reset_Trig_Out();
 
   //MODE ROLL
   if(roll_mode && ppqn_count%roll_scale[scale_type][roll_pointer] == 0 && inst_roll>0){
-    PORTB |= (1<<2);//envoie une impulsion sur la sorti trig CPU a chaque pas
+    Set_CPU_Trig_High();
     Send_Trig_Out();
   }
   if(step_changed){
-
     SR.ShiftOut_Update(temp_step_led,((inst_step_buffer[step_count][pattern_buffer])&(~inst_mute)|inst_roll));
     step_changed=0;
-    PORTB |= (1<<2);//envoie une impulsion sur la sorti trig CPU a chaque pas
-
+    Set_CPU_Trig_High();
   }
   else{
     SR.ShiftOut_Update(temp_step_led,inst_roll);
@@ -62,7 +60,7 @@ void Count_96PPQN()
     //la premiere note apres l'appuie sur start doit etre decale d'une pulsation 
     //de PPQN pour etre calée avec la premiere note de la machine en SLAVE DIN
     if (first_play_A && (ppqn_count==1)){
-      PORTB |= (1<<2);//envoie une impulsion sur la sorti trig CPU a chaque pas
+      Set_CPU_Trig_High();
       SR.ShiftOut_Update(temp_step_led,(inst_step_buffer[0][pattern_buffer])&(~inst_mute));
       first_play_A=0;//initialise le flag
     }
@@ -136,7 +134,7 @@ void Count_96PPQN()
   {
   }//tempo pour que la pulse CPU soit egal a 1ms
 
-  PORTB &= ~(1<<2);// met a 0 la sorti TRIG CPU
+  Set_CPU_Trig_Low();
 
 }
 
@@ -173,11 +171,11 @@ ISR (PCINT3_vect)
   Reset_Trig_Out();
   //PLAY=================================================================
   if(PIND & (1<<4) && play){
-    PORTB &= ~(1<<2);// met a 0 la sorti TRIG CPU;
+    Set_CPU_Trig_Low();
 
     //MODE ROLL
     if(roll_mode && ppqn_count%(roll_scale[scale_type][roll_pointer]/4) == 0 && inst_roll>0){//
-      PORTB |= (1<<2);//envoie une impulsion sur la sorti trig CPU a chaque pas
+      Set_CPU_Trig_High();
       //SR.ShiftOut_Update(temp_step_led,inst_roll);
       //Send_Trig_Out();
     }
@@ -202,7 +200,7 @@ ISR (PCINT3_vect)
     if(first_play){
       MIDI_Send(0xfa);//Serial1.write(0xfa);//Midi Start  
       ppqn_count=0;
-      PORTB |= 1<<2;//envoie une impulsion sur la sorti trig CPU a chaque pas
+      Set_CPU_Trig_High();
       SR.ShiftOut_Update(temp_step_led,inst_step_buffer[0][pattern_buffer]&(~inst_mute));
       Send_Trig_Out();
       first_play=0;
@@ -237,7 +235,7 @@ ISR (PCINT3_vect)
         }
       }
       step_changed=1;//flag que le pas a change
-      PORTB |= 1<<2;//envoie une impulsion sur la sorti trig CPU a chaque pas
+      Set_CPU_Trig_High();
       if(step_count>=nbr_step[pattern_buffer]){
         step_count=0;
         if(load_pattern_ok){

--- a/Yocto/Interruption_fonction.ino
+++ b/Yocto/Interruption_fonction.ino
@@ -13,18 +13,19 @@ void Count_96PPQN()
   //Set_CPU_Trig_Low();
   Reset_Trig_Out();
 
-  //MODE ROLL
-  if(roll_mode && ppqn_count%roll_scale[scale_type][roll_pointer] == 0 && inst_roll>0){
-    Set_CPU_Trig_High();
-  }
-  if(step_changed){
+  if (step_changed) {
+    step_changed=0;
     SR.ShiftOut_Update(temp_step_led,((inst_step_buffer[step_count][pattern_buffer])&(~inst_mute)|inst_roll));
     Send_Trig_Out();
-    step_changed=0;
     Set_CPU_Trig_High();
   }
-  else{
+  else {
     SR.ShiftOut_Update(temp_step_led,inst_roll);
+    //MODE ROLL
+    if (roll_mode && ppqn_count%roll_scale[scale_type][roll_pointer] == 0 && inst_roll>0) {
+      Send_Trig_Out();
+      Set_CPU_Trig_High();
+    }
   }
 
   ppqn_count++;//incremente le compteur PPQN96

--- a/Yocto/Interruption_fonction.ino
+++ b/Yocto/Interruption_fonction.ino
@@ -16,10 +16,10 @@ void Count_96PPQN()
   //MODE ROLL
   if(roll_mode && ppqn_count%roll_scale[scale_type][roll_pointer] == 0 && inst_roll>0){
     Set_CPU_Trig_High();
-    Send_Trig_Out();
   }
   if(step_changed){
     SR.ShiftOut_Update(temp_step_led,((inst_step_buffer[step_count][pattern_buffer])&(~inst_mute)|inst_roll));
+    Send_Trig_Out();
     step_changed=0;
     Set_CPU_Trig_High();
   }

--- a/Yocto/Interruption_fonction.ino
+++ b/Yocto/Interruption_fonction.ino
@@ -16,12 +16,11 @@ void Count_96PPQN()
   //MODE ROLL
   if(roll_mode && ppqn_count%roll_scale[scale_type][roll_pointer] == 0 && inst_roll>0){
     PORTB |= (1<<2);//envoie une impulsion sur la sorti trig CPU a chaque pas
-
+    Send_Trig_Out();
   }
   if(step_changed){
 
     SR.ShiftOut_Update(temp_step_led,((inst_step_buffer[step_count][pattern_buffer])&(~inst_mute)|inst_roll));
-    Send_Trig_Out();
     step_changed=0;
     PORTB |= (1<<2);//envoie une impulsion sur la sorti trig CPU a chaque pas
 
@@ -53,8 +52,8 @@ void Count_96PPQN()
     if(first_play){
       MIDI_Send(0xfa);//Serial1.write(0xfa);//Midi Start
       ppqn_count=0;//initialise le compteur PPQN
-      PORTD |= (1<<5);// met au niveau haut le sorti Din start
-      PORTD &= ~(1<<4);// met au niveau bas le sorti Din 
+      Set_Dinsync_Run_High();
+      Set_Dinsync_Clock_Low();
       Send_Trig_Out();
       first_play=0;
     }
@@ -118,7 +117,7 @@ void Count_96PPQN()
     }
     step_count=0;//reinitialise a 0 le step compteur
     debut_mesure_count=0;
-    PORTD &= ~(1<<5);//met au niveau bas la sorti DIN start =>STOP
+    Set_Dinsync_Run_Low();
     if (tempo_led_count>=48){
       tempo_led_count=0;//si le compteur egale un temps on le reinitialise
       tempo_led_flag=!tempo_led_flag;//on alterne la valeur du flag de la led tempo.
@@ -157,7 +156,7 @@ void Count_Clock() {
     if (dinsync_clock_timeout != 0) {
       dinsync_clock_timeout--;
       if (dinsync_clock_timeout == 0) {
-        PORTD &= ~(1<<4); // Lower the clock signal.
+        Set_Dinsync_Clock_Low();
       }
     }
   }

--- a/Yocto/Main_Loop.ino
+++ b/Yocto/Main_Loop.ino
@@ -81,7 +81,7 @@ void loop(){
       if(play){
         play=0;
         MIDI_Send(0xfc);//envoi un stop midi (send a MIDI stop)
-        PORTD &= ~(1<<5);//met au niveau bas la sorti DIN start =>STOP
+        Set_Dinsync_Run_Low();
         button_play_count=0;
       }
     }
@@ -103,7 +103,7 @@ void loop(){
       if(play){
         play=0;
         MIDI_Send(0xfc);//envoi un stop midi (send a MIDI stop)
-        PORTD &= ~(1<<5);//met au niveau bas la sorti DIN start =>STOP
+        Set_Dinsync_Run_Low();
         button_play_count=0;
       }
     }
@@ -133,7 +133,7 @@ void loop(){
       if(play){
         play=0;
         MIDI_Send(0xfc);//envoi un stop midi (send a MIDI stop)
-        PORTD &= ~(1<<5);//met au niveau bas la sorti DIN start =>STOP
+        Set_Dinsync_Run_Low();
         button_play_count=0;
       }
     }
@@ -161,7 +161,7 @@ void loop(){
       if(play){
         play=0;
         MIDI_Send(0xfc);//envoi un stop midi
-        PORTD &= ~(1<<5);//met au niveau bas la sorti DIN start =>STOP
+        Set_Dinsync_Run_Low();
         button_play_count=0;
       }
     }
@@ -188,7 +188,7 @@ void loop(){
       if(play){
         play=0;
         MIDI_Send(0xfc);//envoi un stop midi (send a MIDI stop)
-        PORTD &= ~(1<<5);//met au niveau bas la sorti DIN start =>STOP
+        Set_Dinsync_Run_Low();
         button_play_count=0;
       }
       //TapeTempoInit();
@@ -214,7 +214,7 @@ void loop(){
       if(play){
         play=0;
         MIDI_Send(0xfc);//envoi un stop midi (send a MIDI stop)
-        PORTD &= ~(1<<5);//met au niveau bas la sorti DIN start =>STOP
+        Set_Dinsync_Run_Low();
         button_play_count=0;
       }
       TapeTempoInit();
@@ -240,7 +240,7 @@ void loop(){
       if(play){
         play=0;
         MIDI_Send(0xfc);//envoi un stop midi (send a MIDI stop)
-        PORTD &= ~(1<<5);//met au niveau bas la sorti DIN start =>STOP
+        Set_Dinsync_Run_Low();
         button_play_count=0;
       }
     }
@@ -263,7 +263,7 @@ void loop(){
       if(play){
         play=0;
         MIDI_Send(0xfc);//envoi un stop midi
-        PORTD &= ~(1<<5);//met au niveau bas la sorti DIN start =>STOP
+        Set_Dinsync_Run_Low();
         button_play_count=0;
       }
       MIDI.setHandleClock(Handle_Clock);// Callback Clock MIDI
@@ -296,7 +296,7 @@ void loop(){
       if(play) {
         play=0;
         MIDI_Send(0xfc);//envoi un stop midi
-        PORTD &= ~(1<<5);//met au niveau bas la sorti DIN start =>STOP
+        Set_Dinsync_Run_Low();
         button_play_count=0;
       }
       //initialise les leds suivant le channel selectionner et les sortie des instru a 0

--- a/Yocto/Main_Loop.ino
+++ b/Yocto/Main_Loop.ino
@@ -358,9 +358,9 @@ void loop(){
     //
     SR.ShiftOut_Update(temp_step_led,inst_midi_buffer);
 
-    PORTB |= (1<<2);//envoie une impulsion sur la sorti trig CPU a chaque pas
+    Set_CPU_Trig_High();
     delayMicroseconds(10);
-    PORTB &= ~(1<<2);
+    Set_CPU_Trig_Low();
 
     Send_Trig_Out_Midi();
 

--- a/Yocto/Midi_Play.ino
+++ b/Yocto/Midi_Play.ino
@@ -56,7 +56,7 @@ void Handle_Stop() {
     Set_Dinsync_Run_Low();
     play = 0;
     step_count = 0;
-    PORTB &= ~(1<<2);// met a 0 la sorti TRIG CPU
+    Set_CPU_Trig_Low();
 }
 
 
@@ -74,7 +74,7 @@ void Handle_Clock() {
 
     //MODE ROLL
     if(roll_mode && ppqn_count%(roll_scale[scale_type][roll_pointer]/4) == 0 && inst_roll>0) {
-        PORTB |= (1<<2);//envoie une impulsion sur la sorti trig CPU a chaque pas
+        Set_CPU_Trig_High();
         //SR.ShiftOut_Update(temp_step_led,inst_roll);
         //Send_Trig_Out();
     }
@@ -82,7 +82,7 @@ void Handle_Clock() {
         SR.ShiftOut_Update(temp_step_led,((inst_step_buffer[step_count][pattern_buffer])&(~inst_mute)|inst_roll));
         Send_Trig_Out();
         step_changed = 0;
-	    PORTB |= (1<<2);//envoie une impulsion sur la sorti trig CPU a chaque pas
+	    Set_CPU_Trig_High();
     }
     else if (!first_play) {
         SR.ShiftOut_Update(temp_step_led,inst_roll);
@@ -103,7 +103,7 @@ void Handle_Clock() {
 
         if (first_play) {
 	        //ppqn_count = 0;   //initialise le compteur PPQN
-            PORTB |= 1<<2;    //envoie une impulsion sur la sorti trig CPU a chaque pas
+            Set_CPU_Trig_High();
             SR.ShiftOut_Update(temp_step_led,((inst_step_buffer[step_count][pattern_buffer])&(~inst_mute)|inst_roll));
             Send_Trig_Out();
             first_play = 0;   //initialise le flag
@@ -155,7 +155,7 @@ void Handle_Clock() {
             pattern_count = 0;      //reinitilise le compteur de position du song
         }
     }
-    PORTB &= ~(1<<2);         // met a 0 la sorti TRIG CPU
+    Set_CPU_Trig_Low();
 }
 
 
@@ -192,7 +192,7 @@ void Disconnect_Callback() {
     DDRD |= (1<<6);//sortie trig out
     inst_midi_buffer=0;
     SR.ShiftOut_Update(temp_step_led,inst_midi_buffer);
-    PORTB &=~1<<2;
+    Set_CPU_Trig_Low();
     */
     PORTC &= ~(B11111100);//clear les edits leds dans ce mode 
     SR.Led_Step_Write(0);//tous les leds Step Off

--- a/Yocto/Midi_Play.ino
+++ b/Yocto/Midi_Play.ino
@@ -1,44 +1,5 @@
 #define NOTE_ON 0x90 //note on sur canal 1
 
-/////////////////////////////////////////////////////////////////////////////////
-//Interruption midi en mode midi play
-// ce qui est different de l interruption en mode pattern play c'est
-//que le shift register des inst est update suivant la note midi recu
-/////////////////////////////////////////////////////////////////////////////////
-/*void Midi_Synchro_Midi_Play(){ 
- 
- if(Serial1.available()>0){
- byte data;
- data = Serial1.read();//enregistre le byte recu dans la variable data
- Serial1.write(data);//echo vers la sorti MIDI OUT de l'entrée MIDI
- switch (data){
- 
- //MIDI START
- case 0xfa:
- PORTD |= (1<<5);// met au niveau haut le sorti Din start
- play=1;
- ppqn_count=0;
- first_play=1;
- break;
- 
- //MIDI STOP
- case 0xfc:
- PORTD&=~(1<<5);//met a 0 la sorti DIN start
- play=0;
- step_count=0;
- break;
- 
- //MIDI CLOCK
- case 0xf8:
- PORTD|=(1<<4);//met a 1 la clock DIN
- delayMicroseconds (2000);//delay neccessaire pour que le cycle de la clock soit correct en DIN_CLK
- PORTD&=~(1<<4);//met a o la clock DIN
- break;
- 
- }
- }  
- }*/
-
 
 void Handle_NoteOn(byte channel, byte pitch, byte velocity) {
     if (velocity == 0){
@@ -84,7 +45,7 @@ void Handle_NoteOff(byte channel, byte pitch, byte velocity) {
 
 
 void Handle_Start() {
-    PORTD |= (1<<5);// met au niveau haut le sorti Din start
+    Set_Dinsync_Run_High();
     play = 1;
     ppqn_count = 0;
     first_play = 1;
@@ -92,7 +53,7 @@ void Handle_Start() {
 
 
 void Handle_Stop() {
-    PORTD &= ~(1<<5);//met a 0 la sorti DIN start
+    Set_Dinsync_Run_Low();
     play = 0;
     step_count = 0;
     PORTB &= ~(1<<2);// met a 0 la sorti TRIG CPU
@@ -110,10 +71,6 @@ void Handle_Clock() {
     else {
         Set_Dinsync_Clock_High();
     }
-    
-
-    //bitWrite(PORTD,4,!(bitRead (PIND,4)));
-    //PORTB &= ~(1<<2);// met a 0 la sorti TRIG CPU
 
     //MODE ROLL
     if(roll_mode && ppqn_count%(roll_scale[scale_type][roll_pointer]/4) == 0 && inst_roll>0) {

--- a/Yocto/Mode_Pattern.ino
+++ b/Yocto/Mode_Pattern.ino
@@ -296,9 +296,9 @@ void Mode_Pattern(){
         // However in practice this usually does not work. Double triggers are better than no
         // triggers at all, so we go for the possible double trigger for now:
         SR.Inst_Send(1<<selected_inst);
-        PORTB |= (1<<2);
+        Set_CPU_Trig_High();
         delayMicroseconds(10);
-        PORTB &= ~(1<<2);
+        Set_CPU_Trig_Low();
         // Make sure the change is saved.
         selected_pattern_edited=1;
         selected_pattern_edited_saved=1;

--- a/Yocto/Mode_Synchro.ino
+++ b/Yocto/Mode_Synchro.ino
@@ -46,21 +46,3 @@ void Mode_Synchro(byte mode) {
     break;
   }
 }
-
-void Set_Dinsync_Clock_High() {
-  PORTD |= (1<<4); // Set the clock high.
-  dinsync_clock_timeout = 4; // 4ms clock.
-}
-
-
-void Set_Dinsync_Clock_Low() {
-  PORTD &= ~(1<<4); // Lower the clock signal.
-}
-
-void Set_Dinsync_Run_High() {
-  PORTD |= (1<<5); // Set Run = 1.
-}
-
-void Set_Dinsync_Run_Low() {
-  PORTD &= ~(1<<5); // Set Run = 0.
-}

--- a/Yocto/Mode_Synchro.ino
+++ b/Yocto/Mode_Synchro.ino
@@ -48,11 +48,19 @@ void Mode_Synchro(byte mode) {
 }
 
 void Set_Dinsync_Clock_High() {
-  PORTD |= (1<<4);//met a 1 la clock DIN
+  PORTD |= (1<<4); // Set the clock high.
   dinsync_clock_timeout = 4; // 4ms clock.
 }
 
 
 void Set_Dinsync_Clock_Low() {
   PORTD &= ~(1<<4); // Lower the clock signal.
+}
+
+void Set_Dinsync_Run_High() {
+  PORTD |= (1<<5); // Set Run = 1.
+}
+
+void Set_Dinsync_Run_Low() {
+  PORTD &= ~(1<<5); // Set Run = 0.
 }

--- a/Yocto/Trig_out.ino
+++ b/Yocto/Trig_out.ino
@@ -11,9 +11,15 @@ void Reset_Trig_Out()
 
 void Send_Trig_Out()
 {
-  if (bitRead((inst_step_buffer[step_count][pattern_buffer])&(~inst_mute),TRIG1)) digitalWrite(TRIG1_PIN,LOW);
-  if (bitRead((inst_step_buffer[step_count][pattern_buffer])&(~inst_mute),TRIG2)) digitalWrite(TRIG2_PIN,LOW);
-  if (bitRead((inst_step_buffer[step_count][pattern_buffer])&(~inst_mute),TRIG3)) digitalWrite(TRIG3_PIN,LOW);
+  if (bitRead((inst_step_buffer[step_count][pattern_buffer])&(~inst_mute)|inst_roll, TRIG1)) {
+    digitalWrite(TRIG1_PIN, LOW);
+  }
+  if (bitRead((inst_step_buffer[step_count][pattern_buffer])&(~inst_mute)|inst_roll, TRIG2)) {
+    digitalWrite(TRIG2_PIN, LOW);
+  }
+  if (bitRead((inst_step_buffer[step_count][pattern_buffer])&(~inst_mute)|inst_roll, TRIG3)) {
+    digitalWrite(TRIG3_PIN, LOW);
+  }
 }
 
 void Send_Trig_Out_Midi()

--- a/Yocto/Trig_out.ino
+++ b/Yocto/Trig_out.ino
@@ -9,15 +9,15 @@ void Reset_Trig_Out()
   digitalWrite(TRIG3_PIN, HIGH);
 }
 
-void Send_Trig_Out()
+void Send_Trig_Out(int trig_outs)
 {
-  if (bitRead((inst_step_buffer[step_count][pattern_buffer])&(~inst_mute)|inst_roll, TRIG1)) {
+  if (bitRead(trig_outs, TRIG1)) {
     digitalWrite(TRIG1_PIN, LOW);
   }
-  if (bitRead((inst_step_buffer[step_count][pattern_buffer])&(~inst_mute)|inst_roll, TRIG2)) {
+  if (bitRead(trig_outs, TRIG2)) {
     digitalWrite(TRIG2_PIN, LOW);
   }
-  if (bitRead((inst_step_buffer[step_count][pattern_buffer])&(~inst_mute)|inst_roll, TRIG3)) {
+  if (bitRead(trig_outs, TRIG3)) {
     digitalWrite(TRIG3_PIN, LOW);
   }
 }

--- a/Yocto/Yocto.ino
+++ b/Yocto/Yocto.ino
@@ -325,6 +325,13 @@ void setup() {
   Load_Pattern();//on load le pattern 0
 }
 
+void Set_CPU_Trig_High() {
+  PORTB |= (1<<2);
+}
+
+void Set_CPU_Trig_Low() {
+  PORTB &= ~(1<<2);
+}
 
 void Chenillard() {
   int temp=0;//variable pour le chenillard

--- a/yocto.h
+++ b/yocto.h
@@ -28,6 +28,8 @@ for future versions.
   void Mode_Synchro(byte mode);
   void Set_Dinsync_Clock_High();
   void Set_Dinsync_Clock_Low();
+  void Set_Dinsync_Run_High();
+  void Set_Dinsync_Run_Low();
   void Disconnect_Callback();
   void Handle_Stop();
   void Handle_Clock();

--- a/yocto.h
+++ b/yocto.h
@@ -19,6 +19,8 @@ for future versions.
 
   void Reset_Song();
   void Verticalize_Pattern();
+  void Set_CPU_Trig_High();
+  void Set_CPU_Trig_Low();
   void Send_Trig_Out();
   void Reset_Trig_Out();
   void Handle_NoteOff(byte channel, byte pitch, byte velocity);

--- a/yocto.h
+++ b/yocto.h
@@ -21,7 +21,7 @@ for future versions.
   void Verticalize_Pattern();
   void Set_CPU_Trig_High();
   void Set_CPU_Trig_Low();
-  void Send_Trig_Out();
+  void Send_Trig_Out(int trig_outs);
   void Reset_Trig_Out();
   void Handle_NoteOff(byte channel, byte pitch, byte velocity);
   void Check_Midi_Channel();


### PR DESCRIPTION
There was no "ROLL" on the trigger outs, which sucks as I have been using them a lot recently.
This pull request fixes that, and also rewrites/restructures some of the logic so the code gets more readable:

Functions added:
-   void Set_CPU_Trig_High();
-   void Set_CPU_Trig_Low();
-   void Set_Dinsync_Run_High();
-   void Set_Dinsync_Run_Low();
Those are just wrappers for much repeated parts in the code.

The signature of Send_Trig_Out() now takes _int trig_outs_ as an parameter so that all logic concerning which trig out to trigger gets offloaded to the caller..

Code has been tested with master sync, din sync and midi sync. No known issues.
Here's a link to test the firmware: https://rv0.be/tmp/yocto_firmware_1_2_a_TRIG_ROLL.syx